### PR TITLE
Log details of hashes being checked

### DIFF
--- a/dcp_inspect
+++ b/dcp_inspect
@@ -4499,9 +4499,11 @@ def dcp_inspect( options, arg )
                         end
                       else
                         @check_hashes_limit_hits += 1
-                        @logger.debug "#{ id }: Hash check skipped: File size #{ size_asset.to_k } > #{ bytes_from_nice_bytes( options.check_hashes_limit ).to_k } limit"
-                        hints << "PKL #{ pkl_id }: Hash check skipped: File size #{ size_asset.to_k } > #{ bytes_from_nice_bytes( options.check_hashes_limit ).to_k } limit: Asset #{ id }: #{ asset_file }"
+                        @logger.debug "#{ id }: Hash check skipped: File size #{ size_asset.to_k } > #{ bytes_from_nice_bytes( options.check_hashes_limit ).to_k } limit: Path: #{ asset_file }, Expected hash: #{ hash_listed }"
+                        hints << "PKL #{ pkl_id }: Hash check skipped: File size #{ size_asset.to_k } > #{ bytes_from_nice_bytes( options.check_hashes_limit ).to_k } limit: Asset #{ id }, Path #{ asset_file }, Expected hash: #{ hash_listed }"
                       end
+                    else
+                      @logger.debug "#{ id }: Hash check skipped: Path: #{ asset_file }, Expected hash: #{ hash_listed }"
                     end
                   end
                 end


### PR DESCRIPTION
This PR adds logging of the expected hash values when inspecting a DCP.

Use case is: I already know the SHA1 hashes of the actual files on disc (they've been checked already during the process of copying them from drive to drive). So rather than `dcp_inspect` calculating the hash again of the files on disc, I only need it to output what the _expected_ hash values are. Then I can check the expected hashes against what I already know the actual hashes are, and so ascertain whether the DCP is corrupt or not.
