### PR TITLE
dcp_inspect: Suppress errors for VF DCPs

### DIFF
--- a/dcp_inspect
+++ b/dcp_inspect
@@ -3833,7 +3833,7 @@ def cpl_inspect_xml( xml, dict, audio_stats, package_dir, errors, hints, info, o
   elsif composition_picture_decomposition_levels.uniq.size == 1 and composition_picture_decomposition_levels.first == nil
     errors << "CPL #{ cpl_id }: Failed to read DecompositionLevels from picture essence. Should not happen"
     cpl_errors = true
-  else
+  elsif composition_picture_decomposition_levels.uniq.size != 0
     errors << "CPL #{ cpl_id }: Found inconsistent image DecompositionLevels values across the composition (#{ composition_picture_decomposition_levels.each_with_index.map { |v, index| 'Reel ' + ( index + 1 ).to_s + ': ' + v.to_s }.join( ', ' ) }). This will produce visual artefacts in reel transitions"
     cpl_errors = true
   end
@@ -3917,7 +3917,7 @@ def cpl_inspect_xml( xml, dict, audio_stats, package_dir, errors, hints, info, o
   elsif composition_sound_channel_formats.uniq.size == 1 and composition_sound_channel_formats.first == nil
     errors << "CPL #{ cpl_id }: Failed to read sound ChannelFormat values from sound essence. Should not happen"
     cpl_errors = true
-  else
+  elsif composition_sound_channel_formats.uniq.size != 0
     errors << "CPL #{ cpl_id }: Found inconsistent sound ChannelFormat values across the composition (#{ composition_sound_channel_formats.each_with_index.map { |v, index| 'Reel ' + ( index + 1 ).to_s + ': ' + v.to_s }.join( ', ' ) }). Playback will fail completely"
     cpl_errors = true
   end


### PR DESCRIPTION
Currently `dcp_inspect` produces errors which are false alarms on VF DCPs where the VF references assets not present in the AssetMap:

```
Error: CPL ...: Found inconsistent image DecompositionLevels values across the composition (). This will produce visual artefacts in reel transitions
Error: CPL ...: Found inconsistent sound ChannelFormat values across the composition (). Playback will fail completely
```

This PR suppresses these errors where there's no picture or audio which can be checked in the CPL.