### PR TITLE
Feature: Add `--full-ids` option

### DIFF
--- a/dcp_inspect
+++ b/dcp_inspect
@@ -206,6 +206,7 @@ class Options
     options.image_analysis = false # not yet implemented
     options.audio_analysis = true
     options.validate = true
+    options.full_ids = false
     options.as_asset_store = false
     options.verbosity = [ 'debug', 'dev' ]
     options.logfile = nil
@@ -234,6 +235,9 @@ BANNER
       end
       opts.on( '--no-schema', 'Skip schema checks' ) do
         options.validate = false
+      end
+      opts.on( '--full-ids', 'Print full asset IDs in reel reports' ) do
+        options.full_ids = true
       end
       opts.on( '-s', '--as-asset-store', 'Simulate asset store by merging all collected AM dictionaries' ) do
         options.as_asset_store = true
@@ -3688,7 +3692,7 @@ def cpl_inspect_xml( xml, dict, audio_stats, package_dir, errors, hints, info, o
       end # if dict
 
       begin
-        reels_report << "#{ "%6s" % duration }  #{ edit_rate.nil? ? 'EditRate funk' : Timecode.new( duration, edit_rate ) } @ #{ edit_rate }  Entry #{ Timecode.new( entry_point, edit_rate ) }  #{ asset_id.split( '-' ).first }  #{ asset.node_name }\t(#{ meta_report })"
+        reels_report << "#{ "%6s" % duration }  #{ edit_rate.nil? ? 'EditRate funk' : Timecode.new( duration, edit_rate ) } @ #{ edit_rate }  Entry #{ Timecode.new( entry_point, edit_rate ) }  #{ options.full_ids ? asset_id : asset_id.split( '-' ).first }  #{ asset.node_name }#{ options.full_ids && asset.node_name.length < 10 ? "\t" : "" }\t(#{ meta_report })"
       rescue Exception => e
         errors << "#{ cpl_reel }: Duration #{ duration }: EditRate #{ edit_rate }: #{ e.message }"
         cpl_errors = true


### PR DESCRIPTION
This PR adds a new command line option `--full-ids` to output full asset IDs in reel reports.

For human-readability, the current output is nice. However, when parsing `dcp_inspect`'s output in an automated process, having the full asset IDs is preferable. It's also useful with supplemental/VF DCPs where the full asset IDs do not appear anywhere else in the output for assets not included in the AssetMap.

The option is disabled by default i.e. default output is the same as before this PR.

Default output:

```
Number of Reels:  1
Reel 1:
142120  01:38:41+16 @ 24.0  Entry 00:00:00+00  c84584c0  MainPicture	(Referenced asset file not listed in Assetmap dictionary: Supplemental/VF/External)
142120  01:38:41+16 @ 24.0  Entry 00:00:00+00  74a9221c  MainSound	(Referenced asset file not listed in Assetmap dictionary: Supplemental/VF/External)
142120  01:38:41+16 @ 24.0  Entry 00:00:00+00  50a6cb6f  MainSubtitle	(SMPTE, 01:38:41+16, plaintext, timed text)
Total duration:
142120  01:38:41+16 @ 24.0
```

Output with `--full-ids`:

```
Number of Reels:  1
Reel 1:
142120  01:38:41+16 @ 24.0  Entry 00:00:00+00  c84584c0-094b-487b-b4de-35f092e97b2a  MainPicture	(Referenced asset file not listed in Assetmap dictionary: Supplemental/VF/External)
142120  01:38:41+16 @ 24.0  Entry 00:00:00+00  74a9221c-b12e-45d5-adcf-22eb1352f787  MainSound		(Referenced asset file not listed in Assetmap dictionary: Supplemental/VF/External)
142120  01:38:41+16 @ 24.0  Entry 00:00:00+00  50a6cb6f-7e7c-4781-829d-b4cb13daabbf  MainSubtitle	(SMPTE, 01:38:41+16, plaintext, timed text)
Total duration:
142120  01:38:41+16 @ 24.0
```