### PR TITLE
Add `--symlinks` option

### DIFF
--- a/dcp_inspect
+++ b/dcp_inspect
@@ -207,6 +207,7 @@ class Options
     options.audio_analysis = true
     options.validate = true
     options.as_asset_store = false
+    options.follow_symlinks = false
     options.verbosity = [ 'debug', 'dev' ]
     options.logfile = nil
     options.logfile_append = nil
@@ -237,6 +238,9 @@ BANNER
       end
       opts.on( '-s', '--as-asset-store', 'Simulate asset store by merging all collected AM dictionaries' ) do
         options.as_asset_store = true
+      end
+      opts.on( '--symlinks', 'Follow symlinks when searching for files' ) do
+        options.follow_symlinks = true
       end
       opts.on( '-l', '--logfile path', String, 'Write full report to logfile at path' ) do |p|
         options.logfile = p
@@ -4069,10 +4073,10 @@ def cpl_inspect_xml( xml, dict, audio_stats, package_dir, errors, hints, info, o
   return report, errors, hints, info
 end # cpl_inspect_xml
 
-def dir_tree( arg )
+def dir_tree( arg, follow_symlinks )
   package_dir_tree = Array.new
   begin
-    Dir.chdir( arg ) { |d| package_dir_tree = Dir[ "**/*" ] }
+    Dir.chdir( arg ) { |d| package_dir_tree = Dir[ follow_symlinks ? "**{,/*/**}/*" : "**/*" ] }
     #
     # Alternatively consider
     #
@@ -4116,7 +4120,7 @@ def dcp_inspect( options, arg )
   # collect all files dangling below arg
   #
   @package_dir = arg
-  package_dir_tree = dir_tree( @package_dir )
+  package_dir_tree = dir_tree( @package_dir, options.follow_symlinks )
 
   #
   # Find files called what Assetmap(s) would be called.


### PR DESCRIPTION
This PR adds a new command line option `--symlinks` to follow symlinks when finding files in the directory being inspected.

Particularly useful in conjunction with the `--as-asset-store` option if you want to check if a VF DCP and OV DCP marry, and the two DCPs are stored in different locations / on different drives. You can create a new directory, symlink both the DCPs into it, and run `dcp_inspect` on that directory with the `--symlinks` option.